### PR TITLE
migrated to symfony finder

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@ All notable changes in PHPCPD are documented in this file using the [Keep a CHAN
 
 ## [7.0.0] - 2022-MM-DD
 
+### Changed
+
+* [#2](https://github.com/mkrauser/phpcpd/pull/2) Use Symfony Finder to iterate over files
+
 ### Added
 
 * [#199](https://github.com/sebastianbergmann/phpcpd/pull/199): Suffix Tree-based algorithm for code clone detection

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     "require": {
         "php": ">=8.1",
         "ext-dom": "*",
+        "ext-mbstring": "*",
+        "phpunit/php-timer": "^6.0",
         "sebastian/cli-parser": "^2.0",
         "sebastian/version": "^4.0",
-        "phpunit/php-file-iterator": "^4.0",
-        "phpunit/php-timer": "^6.0",
-        "ext-mbstring": "*"
+        "symfony/finder": "^6.3"
     },
     "autoload": {
         "classmap": [

--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -12,7 +12,6 @@ namespace SebastianBergmann\PHPCPD;
 use const PHP_EOL;
 use function count;
 use function printf;
-use SebastianBergmann\FileIterator\Facade;
 use SebastianBergmann\PHPCPD\Detector\Detector;
 use SebastianBergmann\PHPCPD\Detector\Strategy\AbstractStrategy;
 use SebastianBergmann\PHPCPD\Detector\Strategy\DefaultStrategy;
@@ -23,6 +22,7 @@ use SebastianBergmann\PHPCPD\Log\Text;
 use SebastianBergmann\Timer\ResourceUsageFormatter;
 use SebastianBergmann\Timer\Timer;
 use SebastianBergmann\Version;
+use Symfony\Component\Finder\Finder;
 
 final class Application
 {
@@ -55,14 +55,12 @@ final class Application
             return 0;
         }
 
-        $files = (new Facade)->getFilesAsArray(
-            $arguments->directories(),
-            $arguments->suffixes(),
-            '',
-            $arguments->exclude()
-        );
+        $files = (new Finder())->in($arguments->directories())
+            ->notPath($arguments->exclude())
+            ->files()
+            ->name($arguments->suffixes());
 
-        if (empty($files)) {
+        if (iterator_count($files) == 0) {
             print 'No files found to scan' . PHP_EOL;
 
             return 1;
@@ -118,13 +116,14 @@ final class Application
     {
         print <<<'EOT'
 Usage:
-  phpcpd [options] <directory>
+  phpcpd [options] <directories>
 
 Options for selecting files:
 
   --suffix <suffix> Include files with names ending in <suffix> in the analysis
-                    (default: .php; can be given multiple times)
+                    (default: *.php; can be given multiple times)
   --exclude <path>  Exclude files with <path> in their path from the analysis
+                    The patterns given need to be relative to the analyzed paths
                     (can be given multiple times)
 
 Options for analysing files:

--- a/src/CLI/ArgumentsBuilder.php
+++ b/src/CLI/ArgumentsBuilder.php
@@ -52,7 +52,7 @@ final class ArgumentsBuilder
         $directories = $options[1];
         $exclude     = [];
         /** @var list<string> $suffixes */
-        $suffixes         = ['.php'];
+        $suffixes         = ['*.php'];
         $pmdCpdXmlLogfile = null;
         $linesThreshold   = 5;
         $tokensThreshold  = 70;

--- a/src/Detector/Detector.php
+++ b/src/Detector/Detector.php
@@ -11,6 +11,7 @@ namespace SebastianBergmann\PHPCPD\Detector;
 
 use SebastianBergmann\PHPCPD\CodeCloneMap;
 use SebastianBergmann\PHPCPD\Detector\Strategy\AbstractStrategy;
+use Symfony\Component\Finder\Finder;
 
 final class Detector
 {
@@ -21,18 +22,13 @@ final class Detector
         $this->strategy = $strategy;
     }
 
-    /** @param list<string> $files */
-    public function copyPasteDetection(iterable $files): CodeCloneMap
+    public function copyPasteDetection(Finder $files): CodeCloneMap
     {
         $result = new CodeCloneMap;
 
         foreach ($files as $file) {
-            if (empty($file)) {
-                continue;
-            }
-
             $this->strategy->processFile(
-                $file,
+                $file->getRealPath(),
                 $result
             );
         }

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -17,6 +17,7 @@ use SebastianBergmann\PHPCPD\ArgumentsBuilder;
 use SebastianBergmann\PHPCPD\Detector\Strategy\AbstractStrategy;
 use SebastianBergmann\PHPCPD\Detector\Strategy\DefaultStrategy;
 use SebastianBergmann\PHPCPD\Detector\Strategy\StrategyConfiguration;
+use Symfony\Component\Finder\Finder;
 
 /**
  * @covers \SebastianBergmann\PHPCPD\Arguments
@@ -40,19 +41,19 @@ final class DetectorTest extends TestCase
     public function testDetectingSimpleClonesWorks(AbstractStrategy $strategy): void
     {
         $clones = (new Detector($strategy))->copyPasteDetection(
-            [__DIR__ . '/../fixture/Math.php']
+            (new Finder())->in(__DIR__ . '/../fixture')->name('Math.php')
         );
 
         $clones = $clones->clones();
         $files  = $clones[0]->files();
         $file   = current($files);
 
-        $this->assertSame(__DIR__ . '/../fixture/Math.php', $file->name());
+        $this->assertSame(realpath(__DIR__ . '/../fixture/Math.php'), $file->name());
         $this->assertSame(75, $file->startLine());
 
         $file = next($files);
 
-        $this->assertSame(__DIR__ . '/../fixture/Math.php', $file->name());
+        $this->assertSame(realpath(__DIR__ . '/../fixture/Math.php'), $file->name());
         $this->assertSame(139, $file->startLine());
         $this->assertSame(59, $clones[0]->numberOfLines());
         $this->assertSame(136, $clones[0]->numberOfTokens());
@@ -133,23 +134,20 @@ final class DetectorTest extends TestCase
         $strategy->setConfig($config);
 
         $clones = (new Detector($strategy))->copyPasteDetection(
-            [
-                __DIR__ . '/../fixture/a.php',
-                __DIR__ . '/../fixture/b.php',
-            ]
+            (new Finder())->in(dirname(__DIR__) . '/fixture')->name('[a|b].php')
         );
 
         $clones = $clones->clones();
         $files  = $clones[0]->files();
-        $file   = current($files);
-
+        ksort($files);
+        $file = current($files);
         $this->assertCount(1, $clones);
-        $this->assertSame(__DIR__ . '/../fixture/a.php', $file->name());
+        $this->assertSame(dirname(__DIR__) . '/fixture/a.php', $file->name());
         $this->assertSame(4, $file->startLine());
 
         $file = next($files);
 
-        $this->assertSame(__DIR__ . '/../fixture/b.php', $file->name());
+        $this->assertSame(dirname(__DIR__) . '/fixture/b.php', $file->name());
         $this->assertSame(4, $file->startLine());
         $this->assertSame(20, $clones[0]->numberOfLines());
         $this->assertSame(60, $clones[0]->numberOfTokens());
@@ -166,11 +164,7 @@ final class DetectorTest extends TestCase
         $strategy->setConfig($config);
 
         $clones = (new Detector($strategy))->copyPasteDetection(
-            [
-                __DIR__ . '/../fixture/a.php',
-                __DIR__ . '/../fixture/b.php',
-                __DIR__ . '/../fixture/c.php',
-            ]
+            (new Finder())->in(dirname(__DIR__) . '/fixture')->name('[a|b|c].php')
         );
 
         $clones = $clones->clones();
@@ -181,17 +175,17 @@ final class DetectorTest extends TestCase
         $file = current($files);
 
         $this->assertCount(1, $clones);
-        $this->assertSame(__DIR__ . '/../fixture/a.php', $file->name());
+        $this->assertSame(dirname(__DIR__) . '/fixture/a.php', $file->name());
         $this->assertSame(4, $file->startLine());
 
         $file = next($files);
 
-        $this->assertSame(__DIR__ . '/../fixture/b.php', $file->name());
+        $this->assertSame(dirname(__DIR__) . '/fixture/b.php', $file->name());
         $this->assertSame(4, $file->startLine());
 
         $file = next($files);
 
-        $this->assertSame(__DIR__ . '/../fixture/c.php', $file->name());
+        $this->assertSame(dirname(__DIR__) . '/fixture/c.php', $file->name());
         $this->assertSame(4, $file->startLine());
     }
 
@@ -205,10 +199,7 @@ final class DetectorTest extends TestCase
         $config    = new StrategyConfiguration($arguments);
         $strategy->setConfig($config);
         $clones = (new Detector($strategy))->copyPasteDetection(
-            [
-                __DIR__ . '/../fixture/a.php',
-                __DIR__ . '/../fixture/b.php',
-            ]
+            (new Finder())->in(dirname(__DIR__) . '/fixture')->name('[a|b].php')
         );
 
         $this->assertCount(0, $clones->clones());
@@ -224,10 +215,7 @@ final class DetectorTest extends TestCase
         $config    = new StrategyConfiguration($arguments);
         $strategy->setConfig($config);
         $clones = (new Detector($strategy))->copyPasteDetection(
-            [
-                __DIR__ . '/../fixture/a.php',
-                __DIR__ . '/../fixture/b.php',
-            ]
+            (new Finder())->in(__DIR__ . '/../fixture')->name('[a|b].php')
         );
 
         $this->assertCount(0, $clones->clones());
@@ -243,10 +231,7 @@ final class DetectorTest extends TestCase
         $config    = new StrategyConfiguration($arguments);
         $strategy->setConfig($config);
         $clones = (new Detector($strategy))->copyPasteDetection(
-            [
-                __DIR__ . '/../fixture/a.php',
-                __DIR__ . '/../fixture/d.php',
-            ]
+            (new Finder())->in(__DIR__ . '/../fixture')->name('[a|b].php')
         );
 
         $this->assertCount(1, $clones->clones());
@@ -265,10 +250,7 @@ final class DetectorTest extends TestCase
         $detector = new Detector($strategy);
 
         $clones = $detector->copyPasteDetection(
-            [
-                __DIR__ . '/../fixture/e.php',
-                __DIR__ . '/../fixture/f.php',
-            ]
+            (new Finder())->in(__DIR__ . '/../fixture')->name('[e|f].php')
         );
 
         $this->assertCount(0, $clones->clones());
@@ -279,13 +261,7 @@ final class DetectorTest extends TestCase
         $strategy->setConfig($config);
 
         $clones = $detector->copyPasteDetection(
-            [
-                __DIR__ . '/../fixture/e.php',
-                __DIR__ . '/../fixture/f.php',
-            ],
-            7,
-            10,
-            true
+            (new Finder())->in(__DIR__ . '/../fixture')->name('[e|f].php')
         );
 
         $this->assertCount(1, $clones->clones());

--- a/tests/unit/EditDistanceTest.php
+++ b/tests/unit/EditDistanceTest.php
@@ -14,6 +14,7 @@ use SebastianBergmann\PHPCPD\ArgumentsBuilder;
 use SebastianBergmann\PHPCPD\Detector\Strategy\DefaultStrategy;
 use SebastianBergmann\PHPCPD\Detector\Strategy\StrategyConfiguration;
 use SebastianBergmann\PHPCPD\Detector\Strategy\SuffixTreeStrategy;
+use Symfony\Component\Finder\Finder;
 
 /**
  * @covers \SebastianBergmann\PHPCPD\Arguments
@@ -45,10 +46,7 @@ final class EditDistanceTest extends TestCase
         $strategy  = new SuffixTreeStrategy($config);
 
         $clones = (new Detector($strategy))->copyPasteDetection(
-            [
-                __DIR__ . '/../fixture/editdistance1.php',
-                __DIR__ . '/../fixture/editdistance2.php',
-            ],
+            (new Finder())->in(__DIR__ . '/../fixture')->name('editdistance[1|2].php')
         );
 
         $clones = $clones->clones();
@@ -63,10 +61,7 @@ final class EditDistanceTest extends TestCase
         $strategy  = new DefaultStrategy($config);
 
         $clones = (new Detector($strategy))->copyPasteDetection(
-            [
-                __DIR__ . '/../fixture/editdistance1.php',
-                __DIR__ . '/../fixture/editdistance2.php',
-            ],
+            (new Finder())->in(__DIR__ . '/../fixture')->name('editdistance[1|2].php')
         );
 
         $clones = $clones->clones();


### PR DESCRIPTION
This will bring a few minor changes with it:

- suffixes must now be listet as pattern understood by Finder::name(...), see https://symfony.com/doc/current/components/finder.html#file-name
- exclude must be relative to the analyzed path(s), see notPath https://symfony.com/doc/current/components/finder.html#path